### PR TITLE
ensure encoding in UTF-8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
                 <configuration>
                     <source>1.7</source>
                     <target>1.7</target>
+                    <encoding>${project.build.sourceEncoding}</encoding>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
ensure UTF-8, specifically for avoiding encoding problems on windows machine, as in #2
