### PR TITLE
changed character in comment for compatibility

### DIFF
--- a/src/main/java/be/ugent/mmlab/rml/input/extractor/AbstractSourceExtractor.java
+++ b/src/main/java/be/ugent/mmlab/rml/input/extractor/AbstractSourceExtractor.java
@@ -27,7 +27,7 @@ abstract public class AbstractSourceExtractor implements SourceExtractor {
     public Set<String> extractStringTemplate(String stringTemplate) {
         Set<String> result = new HashSet<String>();
         // Curly braces that do not enclose column names MUST be
-        // escaped by a backslash character (“\”).
+        // escaped by a backslash character ("\").
         stringTemplate = stringTemplate.replaceAll("\\\\\\{", "");
         stringTemplate = stringTemplate.replaceAll("\\\\\\}", "");
 


### PR DESCRIPTION
Changed character in comment at line 30 `"`, for compatibility with encoding [cp1252](https://en.wikipedia.org/wiki/Windows-1252).
