### PR TITLE
changed characters “ and ” to "

### DIFF
--- a/src/main/java/be/ugent/mmlab/rml/input/extractor/AbstractSourceExtractor.java
+++ b/src/main/java/be/ugent/mmlab/rml/input/extractor/AbstractSourceExtractor.java
@@ -27,7 +27,7 @@ abstract public class AbstractSourceExtractor implements SourceExtractor {
     public Set<String> extractStringTemplate(String stringTemplate) {
         Set<String> result = new HashSet<String>();
         // Curly braces that do not enclose column names MUST be
-        // escaped by a backslash character (“\”).
+        // escaped by a backslash character ("\").
         stringTemplate = stringTemplate.replaceAll("\\\\\\{", "");
         stringTemplate = stringTemplate.replaceAll("\\\\\\}", "");
 


### PR DESCRIPTION
this solves the following error when building RML on windows:

[ERROR] C:\Users\maxime.lefrancois\NetBeansProjects\RML-Mapper\RML-DataRetrieval\src\main\java\be\ugent\mmlab\rml\input\
extractor\AbstractSourceExtractor.java:[30,51] error: unmappable character for encoding Cp1252